### PR TITLE
Fix/issue 1: adding `--append-results` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ git clone git@git.github.com/bogdzn/gork.git
 
 cd gork
 
-make build
+make
 
 # or, with Docker
 make docker
+
+
+# if you wish to show the current available recipes
+make help
 ```
 
 With docker:
@@ -38,6 +42,7 @@ Usage:
   gork [flags]
 
 Flags:
+  -a, --append-results           append dork results to out file
   -e, --extensions stringArray   filetype extensions (default [doc,docx,csv,pdf,txt,log,bak,json,xlsx])
   -h, --help                     help for gork
   -o, --outfile string           directory storing dorks results (default "./gork.txt")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -8,7 +8,7 @@ import (
 )
 
 func GetCmdParser(opts *Options) *cobra.Command {
-    var version = "0.0.1";
+    var version = "0.0.2";
     var rootCmd = &cobra.Command{
         Use:   "gork",
         Version: version,
@@ -17,16 +17,26 @@ func GetCmdParser(opts *Options) *cobra.Command {
         Long: `gork is a CLI to perform Google dorks in order to retrieve cool files :)~`,
         Run: func(cmd *cobra.Command, args []string) {
 
+            if (opts.target == "") {
+                println("[!] Please specify target with -t")
+                return
+            }
+
             println("[+] Running gork on " + opts.target)
             dorks := RunSearch(opts)
 
-            fs, err := os.OpenFile(opts.outfile, os.O_CREATE | os.O_APPEND | os.O_WRONLY, 0644)
+            fileOpts := os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+            if (opts.appendResults) {
+                fileOpts = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+            }
+
+            fs, err := os.OpenFile(opts.outfile, fileOpts, 0644)
             if (err != nil) {
                 fmt.Printf("[!] could not open file %s: %s", opts.outfile, err.Error())
                 return
             }
 
-            fs.WriteString("\t-== GORK RESULTS ==-\n\n")
+            fs.WriteString("\t-== GORK RESULTS FOR " + opts.target + " ==-\n\n")
             for extensions, results := range dorks {
                 fs.WriteString("\t--==== " + extensions + " ===-\n")
                 for idx := range results {
@@ -47,6 +57,7 @@ func GetCmdParser(opts *Options) *cobra.Command {
     rootCmd.PersistentFlags().StringVarP(&opts.proxy, "proxy", "p", "", "proxy URL")
     rootCmd.PersistentFlags().StringVarP(&opts.userAgent, "user-agent", "u", defaultUserAgent, "Which user-agent gork should use")
     rootCmd.PersistentFlags().StringArrayVarP(&opts.extensions, "extensions", "e", defaultExtensions, "filetype extensions")
+    rootCmd.PersistentFlags().BoolVarP(&opts.appendResults, "append-results", "a", false, "append dork results to out file")
 
     return rootCmd
 }

--- a/cmd/options.go
+++ b/cmd/options.go
@@ -7,6 +7,7 @@ type Options struct {
 
     /* Out settings */
     outfile         string
+    appendResults   bool
 
     /* Target settings */
     target          string


### PR DESCRIPTION
this CLI flag should be used iff you want to have multiple results in
your outfile. This can be useful for testing, or if you want to run it
on multiple domains through another go module